### PR TITLE
added nodeId to starting the server command

### DIFF
--- a/sources/1-getting-started.md
+++ b/sources/1-getting-started.md
@@ -22,7 +22,7 @@ docker pull ghcr.io/vinceanalytics/vince
 ### Starting server
 
 ```bash
-vince --data=vince-data --domains=example.com
+vince --data=vince-data --domains=example.com --nodeId=1
 ```
 
 This will start vince server listening on port `8080`


### PR DESCRIPTION
Currently if `nodeId` is not mentioned while starting the server, if this flag is not added we get a error like - https://github.com/vinceanalytics/vince/issues/7
But adding the `nodeId` and updating the command to `vince --data=vince-data --domains=example.com --nodeId=1` fixes the issue